### PR TITLE
Allow struct to properly parse array

### DIFF
--- a/db/elasticsearch_mapsets.go
+++ b/db/elasticsearch_mapsets.go
@@ -18,8 +18,8 @@ import (
 
 type ElasticMapsetSearchOptions struct {
 	Search       string               `form:"search" json:"search"`
-	RankedStatus []enums.RankedStatus `form:"ranked_status" json:"ranked_status"`
-	Mode         []enums.GameMode     `form:"mode" json:"mode"`
+	RankedStatus []enums.RankedStatus `form:"ranked_status[]" json:"ranked_status"`
+	Mode         []enums.GameMode     `form:"mode[]" json:"mode"`
 	Page         int                  `form:"page" json:"page"`
 	Limit        int                  `form:"limit" json:"limit"`
 


### PR DESCRIPTION
WIth this change we can use it properly with array, for example: `?page=1&mode[]=1&mode[]=2` will work unlike before.